### PR TITLE
extend provider interface to support provider source ranges

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Bonial-International-GmbH/ingress-monitor-controller
 go 1.12
 
 require (
-	github.com/Bonial-International-GmbH/site24x7-go v0.0.2
+	github.com/Bonial-International-GmbH/site24x7-go v0.0.3
 	github.com/imdario/mergo v0.3.5
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Bonial-International-GmbH/site24x7-go v0.0.1 h1:51bzdUgtWlBfjZanVHCt5
 github.com/Bonial-International-GmbH/site24x7-go v0.0.1/go.mod h1:VlIGpD11eJjemyS+Rmh4pd9bhAwYuXFemVO+nL6OSqs=
 github.com/Bonial-International-GmbH/site24x7-go v0.0.2 h1:N5yUvg6zdIZrY5Jzu0EdzlVn2lDblijZmzxAPcgYTpI=
 github.com/Bonial-International-GmbH/site24x7-go v0.0.2/go.mod h1:VlIGpD11eJjemyS+Rmh4pd9bhAwYuXFemVO+nL6OSqs=
+github.com/Bonial-International-GmbH/site24x7-go v0.0.3 h1:dxJg9+YNE4/n3+s161vooEs1ne6VWzvhfD/yqx918ZM=
+github.com/Bonial-International-GmbH/site24x7-go v0.0.3/go.mod h1:t8PPOZgtwUCU9xodDhmt5ATqTHkIQgyzCkgjze7zz90=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -43,6 +45,8 @@ github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/btree v0.0.0-20160524151835-7d79101e329e/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=

--- a/pkg/provider/fake/provider.go
+++ b/pkg/provider/fake/provider.go
@@ -40,3 +40,13 @@ func (p *Provider) Delete(name string) error {
 
 	return args.Error(0)
 }
+
+// GetIPSourceRanges implements provider.Interface.
+func (p *Provider) GetIPSourceRanges(model *models.Monitor) ([]string, error) {
+	args := p.Called(model)
+	if obj, ok := args.Get(0).([]string); ok {
+		return obj, args.Error(1)
+	}
+
+	return nil, args.Error(1)
+}

--- a/pkg/provider/null/provider.go
+++ b/pkg/provider/null/provider.go
@@ -26,3 +26,9 @@ func (p *Provider) Update(_ *models.Monitor) error {
 func (p *Provider) Delete(_ string) error {
 	return nil
 }
+
+// GetIPSourceRanges implements provider.Interface.
+func (p *Provider) GetIPSourceRanges(model *models.Monitor) ([]string, error) {
+	// We just whitelist localhost for testing here.
+	return []string{"127.0.0.1/32"}, nil
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -25,6 +25,12 @@ type Interface interface {
 	// Delete delete a monitor by its name. Must return an error if the monitor
 	// deletion fails.
 	Delete(name string) error
+
+	// GetIPSourceRanges returns a list of CIDR blocks that the provider is
+	// performing the monitoring checks from. The source ranges are
+	// automatically added to the source range whitelist of the
+	// nginx-ingress-controller if an ingress uses whitelisting.
+	GetIPSourceRanges(model *models.Monitor) ([]string, error)
 }
 
 // New creates a new monitor provider by name. Returns an error if the named


### PR DESCRIPTION
This adds an extension to the provider interface which allows for
dynamic lookup of the source IPs used for the monitor checks. This makes
it possible to implement an admission controller which automatically
adds the monitor provider source IPs to the
`nginx.ingress.kubernetes.io/whitelist-source-range` annotation of an
ingress whenever an ingress monitor is enabled for it.

Right now the code additions are not in use. Usage will be implemented
in a followup PR to keep the amount of changes easy to review.