### PR TITLE
add ingress admission webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,70 @@ You can control the configuration of a website monitor via provider specific
 annotations. For a full list of supported annotations check out the constants
 and their documentation in
 [`pkg/config/annotations.go`](pkg/config/annotations.go).
+
+### Admission Webhook
+
+The `ingress-monitor-controller` also provides an admission webhook which
+automatically adds the monitor provider's source IP ranges to the
+`nginx.ingress.kubernetes.io/whitelist-source-range` annotation of an ingress
+if the following rules apply:
+
+- If the `ingress-monitor.bonial.com/enabled` annotation is `false` or not
+  present, do nothing.
+- If the `nginx.ingress.kubernetes.io/whitelist-source-range` is not present
+  or empty, do nothing.
+- If there are no source ranges for the used monitor provider, do nothing.
+- If the provider source ranges are not already present in the
+  `nginx.ingress.kubernetes.io/whitelist-source-range` annotation, add them
+  automatically.
+
+To make use of the admission webhook you have to start the controller with the
+`--enable-admission` flag to start the HTTP server for the webhook. This will
+also require to provide valid TLS certificate and private key via the the
+`--tls-cert-file` and `--tls-private-key-file` flags. The listen address of the
+admission controller can be configured via `--listen-addr` and defaults to
+`0.0.0.0:443`.
+
+You also need to create a `Service` and a `MutatingWebhookConfiguration`
+similar to this:
+
+```yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-monitor-controller
+spec:
+  ports:
+    - name: https
+      port: 443
+      targetPort: 443
+  selector:
+    app: ingress-monitor-controller
+
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: ingress-monitor-controller
+webhooks:
+  - name: ingress-monitor-controller.bonial.com
+    clientConfig:
+      service:
+        name: ingress-monitor-controller
+        namespace: kube-system
+        path: /admit
+      caBundle: [...the CA bundle...]
+    failurePolicy: Ignore
+    sideEffects: None
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - extensions
+        apiVersions:
+          - '*'
+        resources:
+          - ingresses
+```

--- a/pkg/admission/handler.go
+++ b/pkg/admission/handler.go
@@ -1,0 +1,102 @@
+package admission
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/klog"
+)
+
+const jsonContentType = "application/json"
+
+// universalDeserializer can convert raw data into Go objects that satisfy runtime.Object.
+var universalDeserializer = serializer.NewCodecFactory(runtime.NewScheme()).UniversalDeserializer()
+
+// AdmitFunc is the signature of a function that handles admission requests.
+type AdmitFunc func(*v1beta1.AdmissionRequest) (*v1beta1.AdmissionResponse, error)
+
+// HandlerFunc wraps the AdmitFunc f in an http.HandlerFunc.
+func HandlerFunc(f AdmitFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleAdmissionRequest(w, r, f)
+	})
+}
+
+// handleAdmissionRequest handles the http portion of a request prior to
+// handing to an admit function.
+func handleAdmissionRequest(w http.ResponseWriter, r *http.Request, admit AdmitFunc) {
+	bytes, err := doHandleAdmissionRequest(w, r, admit)
+	if err != nil {
+		bytes = []byte(err.Error())
+	}
+
+	if _, err = w.Write(bytes); err != nil {
+		klog.Errorf("could not write response: %v", err)
+	}
+}
+
+// doHandleAdmissionRequest handles the http portion of a request prior to
+// handing to an admit function.
+func doHandleAdmissionRequest(w http.ResponseWriter, r *http.Request, admit AdmitFunc) ([]byte, error) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return nil, fmt.Errorf(`invalid method %q, only POST requests are allowed`, r.Method)
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return nil, fmt.Errorf("could not read request body: %v", err)
+	}
+
+	if contentType := r.Header.Get("Content-Type"); contentType != jsonContentType {
+		w.WriteHeader(http.StatusBadRequest)
+		return nil, fmt.Errorf("unsupported content type %q, expected %q", contentType, jsonContentType)
+	}
+
+	// The AdmissionReview that was sent to the webhook
+	requestedAdmissionReview := v1beta1.AdmissionReview{}
+
+	_, _, err = universalDeserializer.Decode(body, nil, &requestedAdmissionReview)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return nil, fmt.Errorf("could not deserialize request: %v", err)
+	} else if requestedAdmissionReview.Request == nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return nil, errors.New("malformed admission review: request is nil")
+	}
+
+	klog.V(4).Infof("handling request: %s", requestedAdmissionReview.Request.UID)
+
+	// The AdmissionReview that will be returned
+	responseAdmissionReview := v1beta1.AdmissionReview{}
+
+	responseAdmissionReview.Response, err = admit(requestedAdmissionReview.Request)
+	if err != nil {
+		responseAdmissionReview.Response = &v1beta1.AdmissionResponse{
+			Result: &metav1.Status{
+				Message: err.Error(),
+			},
+		}
+	}
+
+	// Ensure that the request UID is set in the response
+	responseAdmissionReview.Response.UID = requestedAdmissionReview.Request.UID
+
+	klog.V(5).Infof("sending response: %v", responseAdmissionReview.Response)
+
+	bytes, err := json.Marshal(responseAdmissionReview)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return nil, fmt.Errorf("failed to marshal admission response: %v", err)
+	}
+
+	return bytes, nil
+}

--- a/pkg/admission/handler_test.go
+++ b/pkg/admission/handler_test.go
@@ -1,0 +1,140 @@
+package admission
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/api/admission/v1beta1"
+)
+
+func TestHandleAdmissionRequest(t *testing.T) {
+	tests := []struct {
+		name               string
+		requestMethod      string
+		requestHeaders     map[string]string
+		admitFunc          func(*v1beta1.AdmissionRequest) (*v1beta1.AdmissionResponse, error)
+		requestBody        []byte
+		expectedStatusCode int
+		expectedResponse   []byte
+	}{
+		{
+			name:               "only accepts POST requests",
+			requestMethod:      "GET",
+			expectedResponse:   []byte(`invalid method "GET", only POST requests are allowed`),
+			expectedStatusCode: http.StatusMethodNotAllowed,
+		},
+		{
+			name:               "request must have json content-type",
+			requestMethod:      "POST",
+			requestHeaders:     map[string]string{"Content-Type": "application/xml"},
+			expectedResponse:   []byte(`unsupported content type "application/xml", expected "application/json"`),
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:               "request must contain valid json",
+			requestMethod:      "POST",
+			requestHeaders:     map[string]string{"Content-Type": "application/json"},
+			requestBody:        []byte(`invalid json`),
+			expectedResponse:   []byte(`could not deserialize request: couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string "json:\"apiVersion,omitempty\""; Kind string "json:\"kind,omitempty\"" }`),
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:               "admission review must contain a request",
+			requestMethod:      "POST",
+			requestHeaders:     map[string]string{"Content-Type": "application/json"},
+			requestBody:        serializeObject(t, &v1beta1.AdmissionReview{}),
+			expectedResponse:   []byte(`malformed admission review: request is nil`),
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:           "executes admitFunc with request",
+			requestMethod:  "POST",
+			requestHeaders: map[string]string{"Content-Type": "application/json"},
+			requestBody: serializeObject(t, &v1beta1.AdmissionReview{
+				Request: newAdmissionRequestBuilder(t).build(),
+			}),
+			admitFunc: func(*v1beta1.AdmissionRequest) (*v1beta1.AdmissionResponse, error) {
+				return allowedResponse(), nil
+			},
+			expectedResponse:   []byte(`{"response":{"uid":"","allowed":true}}`),
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:           "attaches request UID to response",
+			requestMethod:  "POST",
+			requestHeaders: map[string]string{"Content-Type": "application/json"},
+			requestBody: serializeObject(t, &v1beta1.AdmissionReview{
+				Request: newAdmissionRequestBuilder(t).withUID("1234567890").build(),
+			}),
+			admitFunc: func(*v1beta1.AdmissionRequest) (*v1beta1.AdmissionResponse, error) {
+				return allowedResponse(), nil
+			},
+			expectedResponse:   []byte(`{"response":{"uid":"1234567890","allowed":true}}`),
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:           "json patch is included in the response",
+			requestMethod:  "POST",
+			requestHeaders: map[string]string{"Content-Type": "application/json"},
+			requestBody: serializeObject(t, &v1beta1.AdmissionReview{
+				Request: newAdmissionRequestBuilder(t).withUID("1234567890").build(),
+			}),
+			admitFunc: func(*v1beta1.AdmissionRequest) (*v1beta1.AdmissionResponse, error) {
+				return newAdmissionResponseBuilder(t).
+					withJSONPatch([]patchOperation{
+						{
+							Op: "add", Path: "/metadata/labels/foo", Value: "bar",
+						},
+					}).
+					build(), nil
+			},
+			expectedResponse:   []byte(`{"response":{"uid":"1234567890","allowed":true,"patch":"W3sib3AiOiJhZGQiLCJwYXRoIjoiL21ldGFkYXRhL2xhYmVscy9mb28iLCJ2YWx1ZSI6ImJhciJ9XQ==","patchType":"JSONPatch"}}`),
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:           "admission errors produce rejected responses with status message",
+			requestMethod:  "POST",
+			requestHeaders: map[string]string{"Content-Type": "application/json"},
+			requestBody: serializeObject(t, &v1beta1.AdmissionReview{
+				Request: newAdmissionRequestBuilder(t).withUID("1234567890").build(),
+			}),
+			admitFunc: func(*v1beta1.AdmissionRequest) (*v1beta1.AdmissionResponse, error) {
+				return nil, errors.New("nope, just nope")
+			},
+			expectedResponse:   []byte(`{"response":{"uid":"1234567890","allowed":false,"status":{"metadata":{},"message":"nope, just nope"}}}`),
+			expectedStatusCode: http.StatusOK,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(HandlerFunc(test.admitFunc))
+			defer server.Close()
+
+			buf := bytes.NewBuffer(test.requestBody)
+
+			req, err := http.NewRequest(test.requestMethod, server.URL, buf)
+			require.NoError(t, err)
+
+			for key, val := range test.requestHeaders {
+				req.Header.Set(key, val)
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			responseBody, err := ioutil.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expectedStatusCode, resp.StatusCode)
+			assert.Equal(t, string(test.expectedResponse), string(responseBody))
+		})
+	}
+}

--- a/pkg/admission/helpers_test.go
+++ b/pkg/admission/helpers_test.go
@@ -1,0 +1,94 @@
+package admission
+
+import (
+	"bytes"
+	gojson "encoding/json"
+	"testing"
+
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type admissionRequestBuilder struct {
+	t   *testing.T
+	req *v1beta1.AdmissionRequest
+}
+
+func newAdmissionRequestBuilder(t *testing.T) *admissionRequestBuilder {
+	return &admissionRequestBuilder{
+		t: t,
+		req: &v1beta1.AdmissionRequest{
+			Resource: metav1.GroupVersionResource{
+				Group:    "networking.k8s.io",
+				Version:  "v1beta1",
+				Resource: "ingresses",
+			},
+		},
+	}
+}
+
+func (ar *admissionRequestBuilder) withUID(uid string) *admissionRequestBuilder {
+	ar.req.UID = types.UID(uid)
+	return ar
+}
+
+func (ar *admissionRequestBuilder) withObject(obj runtime.Object) *admissionRequestBuilder {
+	ar.req.Object = runtime.RawExtension{Raw: serializeObject(ar.t, obj)}
+	return ar
+}
+
+func (ar *admissionRequestBuilder) withResource(gvr metav1.GroupVersionResource) *admissionRequestBuilder {
+	ar.req.Resource = gvr
+	return ar
+}
+
+func (ar *admissionRequestBuilder) build() *v1beta1.AdmissionRequest {
+	return ar.req
+}
+
+type admissionResponseBuilder struct {
+	t    *testing.T
+	resp *v1beta1.AdmissionResponse
+}
+
+func newAdmissionResponseBuilder(t *testing.T) *admissionResponseBuilder {
+	return &admissionResponseBuilder{
+		t: t,
+		resp: &v1beta1.AdmissionResponse{
+			Allowed: true,
+		},
+	}
+}
+
+func (ar *admissionResponseBuilder) withJSONPatch(patch []patchOperation) *admissionResponseBuilder {
+	buf, err := gojson.Marshal(patch)
+	if err != nil {
+		ar.t.Fatal(err)
+	}
+
+	pt := v1beta1.PatchTypeJSONPatch
+
+	ar.resp.Patch = buf
+	ar.resp.PatchType = &pt
+	return ar
+}
+
+func (ar *admissionResponseBuilder) build() *v1beta1.AdmissionResponse {
+	return ar.resp
+}
+
+func serializeObject(t *testing.T, obj runtime.Object) []byte {
+	encoder := json.NewSerializer(json.DefaultMetaFactory, nil, nil, false)
+
+	var buf bytes.Buffer
+
+	err := encoder.Encode(obj, &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return buf.Bytes()
+}

--- a/pkg/admission/webhook.go
+++ b/pkg/admission/webhook.go
@@ -1,0 +1,200 @@
+package admission
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Bonial-International-GmbH/ingress-monitor-controller/pkg/config"
+	"github.com/Bonial-International-GmbH/ingress-monitor-controller/pkg/monitor"
+	"k8s.io/api/admission/v1beta1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
+
+const nginxWhitelistSourceRangeAnnotation = "nginx.ingress.kubernetes.io/whitelist-source-range"
+
+var (
+	// ingressResources are the GroupVersionResources that the webhook is
+	// interested in. Resources that do not match any of the are ignored.
+	ingressResources = []metav1.GroupVersionResource{
+		{Group: "networking.k8s.io", Version: "v1beta1", Resource: "ingresses"},
+		{Group: "extensions", Version: "v1beta1", Resource: "ingresses"},
+	}
+)
+
+// patchOperation is an operation of a JSON patch as specified in by the RFC:
+// https://tools.ietf.org/html/rfc6902.
+type patchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+// Webhook is a mutating admission webhook for ingress objects.
+type Webhook struct {
+	service monitor.Service
+}
+
+// NewWebhook creates a new admission webhook.
+func NewWebhook(service monitor.Service) *Webhook {
+	return &Webhook{
+		service: service,
+	}
+}
+
+// Admit handles an admission request and patches it if necessary. Patching may
+// only happen on the nginx.ingress.kubernetes.io/whitelist-source-range
+// annotation of an ingress object if necessary.
+func (c *Webhook) Admit(ar *v1beta1.AdmissionRequest) (*v1beta1.AdmissionResponse, error) {
+	if !isSupportedResource(ar.Resource) {
+		klog.V(1).Infof("ignoring unsupported resource %v", ar.Resource)
+		return allowedResponse(), nil
+	}
+
+	ingress := &extensionsv1beta1.Ingress{}
+
+	_, _, err := universalDeserializer.Decode(ar.Object.Raw, nil, ingress)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode ingress object: %v", err)
+	}
+
+	klog.V(5).Infof("decoded ingress object %#v", ingress)
+
+	if !shouldPatchSourceRangeWhitelist(ingress) {
+		klog.V(4).Infof("ingress %s/%s does not require patching of source range whitelist", ingress.Namespace, ingress.Name)
+		return allowedResponse(), nil
+	}
+
+	providerSourceRanges, err := c.service.GetProviderIPSourceRanges(ingress)
+	if err != nil {
+		klog.Errorf("skipping update of source range whitelist for ingress %s/%s due to: %v", ingress.Namespace, ingress.Name, err)
+		return allowedResponse(), nil
+	}
+
+	if len(providerSourceRanges) == 0 {
+		klog.V(4).Infof("no provider source ranges available for ingress %s/%s", ingress.Namespace, ingress.Name)
+		return allowedResponse(), nil
+	}
+
+	sourceRanges, updated := mergeProviderSourceRanges(ingress, providerSourceRanges)
+	if !updated {
+		klog.V(4).Infof("no source range update needed for ingress %s/%s", ingress.Namespace, ingress.Name)
+		return allowedResponse(), nil
+	}
+
+	patch, err := createSourceRangeWhitelistPatch(nginxWhitelistSourceRangeAnnotation, sourceRanges)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JSON patch for ingress %s/%s: %v", ingress.Namespace, ingress.Name, err)
+	}
+
+	klog.Infof("patching ingress %s/%s: %s", ingress.Namespace, ingress.Name, string(patch))
+
+	return patchResponse(patch), nil
+}
+
+// allowedResponse is just a convenience func to signal that an object should
+// be admitted to the cluster.
+func allowedResponse() *v1beta1.AdmissionResponse {
+	return &v1beta1.AdmissionResponse{Allowed: true}
+}
+
+// patchResponse admits an object to the cluster and also includes a JSON match
+// with the mutation operations that should be performed on the object.
+func patchResponse(patch []byte) *v1beta1.AdmissionResponse {
+	pt := v1beta1.PatchTypeJSONPatch
+
+	return &v1beta1.AdmissionResponse{
+		Allowed:   true,
+		Patch:     patch,
+		PatchType: &pt,
+	}
+}
+
+// isSupportedResource returns true if gvr matches one of the supported
+// GroupVersionResources.
+func isSupportedResource(gvr metav1.GroupVersionResource) bool {
+	for _, res := range ingressResources {
+		if res == gvr {
+			return true
+		}
+	}
+
+	return false
+}
+
+// shouldPatchSourceRangeWhitelist returns true if the source range whitelist
+// of an ingress should be patched. Patching is necessary if the ingress has a
+// monitor enabled and has configured the
+// nginx.ingress.kubernetes.io/whitelist-source-range annotation to only allow
+// traffic from whitelisted sources.
+func shouldPatchSourceRangeWhitelist(ingress *extensionsv1beta1.Ingress) bool {
+	annotations := config.Annotations(ingress.Annotations)
+
+	if !annotations.BoolValue(config.AnnotationEnabled) {
+		return false
+	}
+
+	return len(ingress.Annotations[nginxWhitelistSourceRangeAnnotation]) > 0
+}
+
+// createSourceRangeWhitelistPatch creates a JSON patch for the
+// nginx.ingress.kubernetes.io/whitelist-source-range annotation of an ingress,
+// which will replace it with the provided sourceRanges. It returns the
+// marshaled bytes of the JSON patch and an error which is non-nil if
+// marshaling the patch to JSON failed.
+func createSourceRangeWhitelistPatch(annotationKey string, sourceRanges []string) ([]byte, error) {
+	// Slashes need to be escaped with ~1 in json patches, see:
+	// https://tools.ietf.org/html/rfc6901#section-3
+	annotationKey = strings.ReplaceAll(annotationKey, "/", "~1")
+
+	patchOperations := []patchOperation{
+		{
+			Op:    "replace",
+			Path:  "/metadata/annotations/" + annotationKey,
+			Value: strings.Join(sourceRanges, ","),
+		},
+	}
+
+	return json.Marshal(patchOperations)
+}
+
+// mergeProviderSourceRanges merges the providerSourceRanges into the source
+// ranges that are configured in the ingresses' whitelist and returns the final
+// whitelist as slice of strings. It ensures that IP ranges that are already
+// present are not added again. The second return value denotes whether the
+// source ranges changed (true) or not (false).
+func mergeProviderSourceRanges(ingress *extensionsv1beta1.Ingress, providerSourceRanges []string) ([]string, bool) {
+	sourceRanges := strings.Split(ingress.Annotations[nginxWhitelistSourceRangeAnnotation], ",")
+	missingSourceRanges := difference(providerSourceRanges, sourceRanges)
+
+	if len(missingSourceRanges) == 0 {
+		return sourceRanges, false
+	}
+
+	klog.V(4).Infof("missing source ranges: %v", missingSourceRanges)
+
+	sourceRanges = append(sourceRanges, missingSourceRanges...)
+
+	return sourceRanges, true
+}
+
+// difference returns elements that are in a but not in b.
+func difference(a, b []string) []string {
+	seen := make(map[string]struct{}, len(b))
+
+	for _, el := range b {
+		seen[el] = struct{}{}
+	}
+
+	var diff []string
+
+	for _, el := range a {
+		if _, found := seen[el]; !found {
+			diff = append(diff, el)
+		}
+	}
+
+	return diff
+}

--- a/pkg/admission/webhook_test.go
+++ b/pkg/admission/webhook_test.go
@@ -1,0 +1,190 @@
+package admission
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Bonial-International-GmbH/ingress-monitor-controller/pkg/config"
+	"github.com/Bonial-International-GmbH/ingress-monitor-controller/pkg/monitor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"k8s.io/api/admission/v1beta1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type mockService struct {
+	monitor.Service
+	mock.Mock
+}
+
+func (m *mockService) GetProviderIPSourceRanges(ingress *extensionsv1beta1.Ingress) ([]string, error) {
+	args := m.Called(ingress)
+	if obj, ok := args.Get(0).([]string); ok {
+		return obj, args.Error(1)
+	}
+
+	return nil, args.Error(1)
+}
+
+func TestWebhook_Admit(t *testing.T) {
+	tests := []struct {
+		name                 string
+		request              *v1beta1.AdmissionRequest
+		expectedResponse     *v1beta1.AdmissionResponse
+		providerSourceRanges []string
+		providerErr          error
+		expectError          bool
+		expectedErr          error
+	}{
+		{
+			name: "non-ingress objects are not patched",
+			request: newAdmissionRequestBuilder(t).
+				withResource(metav1.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).
+				build(),
+			expectedResponse: newAdmissionResponseBuilder(t).build(),
+		},
+		{
+			name: "ingress objects without monitor annotation are not patched",
+			request: newAdmissionRequestBuilder(t).
+				withObject(&extensionsv1beta1.Ingress{}).
+				build(),
+			expectedResponse: newAdmissionResponseBuilder(t).build(),
+		},
+		{
+			name: `ingress objects with monitor annotation with value "false" are not patched`,
+			request: newAdmissionRequestBuilder(t).
+				withObject(&extensionsv1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							config.AnnotationEnabled: "false",
+						},
+					},
+				}).
+				build(),
+			expectedResponse: newAdmissionResponseBuilder(t).build(),
+		},
+		{
+			name: `ingress objects without source range whitelist annotation are not patched`,
+			request: newAdmissionRequestBuilder(t).
+				withObject(&extensionsv1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							config.AnnotationEnabled: "true",
+						},
+					},
+				}).
+				build(),
+			expectedResponse: newAdmissionResponseBuilder(t).build(),
+		},
+		{
+			name: `errors while retrieving provider source ranges do not cause object to be rejected`,
+			request: newAdmissionRequestBuilder(t).
+				withObject(&extensionsv1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							config.AnnotationEnabled:            "true",
+							nginxWhitelistSourceRangeAnnotation: "1.2.3.4/32",
+						},
+					},
+				}).
+				build(),
+			providerErr:      errors.New("whoops"),
+			expectedResponse: newAdmissionResponseBuilder(t).build(),
+		},
+		{
+			name: `empty provider source ranges do not cause the object to be patched`,
+			request: newAdmissionRequestBuilder(t).
+				withObject(&extensionsv1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							config.AnnotationEnabled:            "true",
+							nginxWhitelistSourceRangeAnnotation: "1.2.3.4/32",
+						},
+					},
+				}).
+				build(),
+			providerSourceRanges: []string{},
+			expectedResponse:     newAdmissionResponseBuilder(t).build(),
+		},
+		{
+			name: `provider source ranges are merged with the configured whitelist and produce a patch`,
+			request: newAdmissionRequestBuilder(t).
+				withObject(&extensionsv1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							config.AnnotationEnabled:            "true",
+							nginxWhitelistSourceRangeAnnotation: "1.2.3.4/32",
+						},
+					},
+				}).
+				build(),
+			providerSourceRanges: []string{"5.6.7.8/32"},
+			expectedResponse: newAdmissionResponseBuilder(t).withJSONPatch([]patchOperation{
+				{
+					Op:    "replace",
+					Path:  "/metadata/annotations/nginx.ingress.kubernetes.io~1whitelist-source-range",
+					Value: "1.2.3.4/32,5.6.7.8/32",
+				},
+			}).build(),
+		},
+		{
+			name: `already present source ranges are not added again`,
+			request: newAdmissionRequestBuilder(t).
+				withObject(&extensionsv1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							config.AnnotationEnabled:            "true",
+							nginxWhitelistSourceRangeAnnotation: "1.2.3.4/32",
+						},
+					},
+				}).
+				build(),
+			providerSourceRanges: []string{"5.6.7.8/32", "1.2.3.4/32"},
+			expectedResponse: newAdmissionResponseBuilder(t).withJSONPatch([]patchOperation{
+				{
+					Op:    "replace",
+					Path:  "/metadata/annotations/nginx.ingress.kubernetes.io~1whitelist-source-range",
+					Value: "1.2.3.4/32,5.6.7.8/32",
+				},
+			}).build(),
+		},
+		{
+			name: `if provider source ranges are already whitelisted, no patch is created`,
+			request: newAdmissionRequestBuilder(t).
+				withObject(&extensionsv1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							config.AnnotationEnabled:            "true",
+							nginxWhitelistSourceRangeAnnotation: "5.6.7.8/32,1.2.3.4/32,9.10.11.12/32",
+						},
+					},
+				}).
+				build(),
+			providerSourceRanges: []string{"1.2.3.4/32", "5.6.7.8/32"},
+			expectedResponse:     newAdmissionResponseBuilder(t).build(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			svc := &mockService{}
+
+			svc.On("GetProviderIPSourceRanges", mock.Anything).Return(test.providerSourceRanges, test.providerErr)
+
+			c := NewWebhook(svc)
+
+			response, err := c.Admit(test.request)
+			if test.expectError {
+				require.Error(t, err)
+				if test.expectedErr != nil {
+					assert.Equal(t, test.expectedErr, err)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expectedResponse, response)
+			}
+		})
+	}
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -56,8 +56,6 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 
 	defer c.queue.ShutDown()
 
-	klog.Info("starting controller")
-
 	go c.informer.Run(stopCh)
 
 	// Wait for all involved caches to be synced, before processing items from the queue is started.


### PR DESCRIPTION
This adds an admission webhook that can be optionally enabled via the
`--enable-admission` CLI flag. This will also require to provide valid
TLS certificate and private key via the the `--tls-cert-file` and
`--tls-private-key-file` flags. The listen address of the admission
webhook can be configured via `--listen-addr` and defaults to
`0.0.0.0:443`.

When enabled, the admission webhook will accept ingress resources and
may patch the `nginx.ingress.kubernetes.io/whitelist-source-range`
annotation by following these rules:

- if `ingress-monitor.bonial.com/enabled` is `false` or not present, do
  nothing
- if `nginx.ingress.kubernetes.io/whitelist-source-range` is not present
  or empty, do nothing
- if there are no source ranges for the used monitor provider, do nothing
- if the provider source ranges are not present in the
  `nginx.ingress.kubernetes.io/whitelist-source-range` annotation, provide
  a JSON patch which replaces the annotation's value with the updated
  whitelist.

The admission webhook will only mutate, but not validate. It will
only ever reject an admission review if it fails to decode the object
from the admission request, or if a JSON patch could not be marshaled.

In the first case, the object is invalid anyways and would fail
validation in a later step of the admission process. The second case can
only occur if there is a bug in the golang JSON encoder.

It can also happen that retrieving the provider source ranges for an
ingress fails for some reason. In that case, the error is only logged,
but the ingress object is admitted to the cluster nevertheless, only
without patching it with potentially needed provider source ranges.