### PR TITLE
add test for ingress reconciler

### DIFF
--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -48,17 +48,15 @@ func (r *IngressReconciler) Reconcile(req reconcile.Request) (reconcile.Result, 
 
 		err = r.monitorService.DeleteMonitor(ingress)
 	} else if err == nil {
-		createAfter := time.Until(ingress.CreationTimestamp.Add(r.creationDelay))
+		if ingress.Annotations[config.AnnotationEnabled] == "true" {
+			createAfter := time.Until(ingress.CreationTimestamp.Add(r.creationDelay))
 
-		// If a creation delay was configured, we will requeue the
-		// reconciliation until after the creation delay passed.
-		if createAfter > 0 {
-			return reconcile.Result{RequeueAfter: createAfter}, nil
-		}
+			// If a creation delay was configured, we will requeue the
+			// reconciliation until after the creation delay passed.
+			if createAfter > 0 {
+				return reconcile.Result{RequeueAfter: createAfter}, nil
+			}
 
-		annotations := config.Annotations(ingress.Annotations)
-
-		if annotations.BoolValue(config.AnnotationEnabled) {
 			err = r.monitorService.EnsureMonitor(ingress)
 		} else {
 			err = r.monitorService.DeleteMonitor(ingress)

--- a/pkg/controller/reconciler_test.go
+++ b/pkg/controller/reconciler_test.go
@@ -1,0 +1,175 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Bonial-International-GmbH/ingress-monitor-controller/pkg/config"
+	"github.com/Bonial-International-GmbH/ingress-monitor-controller/pkg/monitor/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestIngressReconciler_Reconcile(t *testing.T) {
+	tests := []struct {
+		name        string
+		clientFn    func() client.Client
+		setup       func(*fake.Service)
+		options     config.Options
+		req         reconcile.Request
+		expected    reconcile.Result
+		expectError bool
+		validate    func(*testing.T, client.Client, *fake.Service)
+	}{
+		{
+			name: "it deletes monitors if ingress was deleted",
+			req: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "foo",
+					Namespace: "kube-system",
+				},
+			},
+			setup: func(s *fake.Service) {
+				s.On("DeleteMonitor", &v1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "kube-system",
+					},
+				}).Return(nil)
+			},
+		},
+		{
+			name: "it ensures that monitors are present if ingress has annotation",
+			req: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "bar",
+					Namespace: "kube-system",
+				},
+			},
+			clientFn: func() client.Client {
+				return fakeclient.NewFakeClient(&v1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bar",
+						Namespace: "kube-system",
+						Annotations: map[string]string{
+							config.AnnotationEnabled: "true",
+						},
+					},
+				})
+			},
+			setup: func(s *fake.Service) {
+				s.On("EnsureMonitor", &v1beta1.Ingress{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Ingress",
+						APIVersion: "extensions/v1beta1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bar",
+						Namespace: "kube-system",
+						Annotations: map[string]string{
+							config.AnnotationEnabled: "true",
+						},
+					},
+				}).Return(nil)
+			},
+		},
+		{
+			name: "it deletes monitors if ingress does not have annotation",
+			req: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "bar",
+					Namespace: "kube-system",
+				},
+			},
+			clientFn: func() client.Client {
+				return fakeclient.NewFakeClient(&v1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bar",
+						Namespace: "kube-system",
+					},
+				})
+			},
+			setup: func(s *fake.Service) {
+				s.On("DeleteMonitor", &v1beta1.Ingress{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Ingress",
+						APIVersion: "extensions/v1beta1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bar",
+						Namespace: "kube-system",
+					},
+				}).Return(nil)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var client client.Client
+
+			if test.clientFn != nil {
+				client = test.clientFn()
+			} else {
+				client = fakeclient.NewFakeClient()
+			}
+
+			svc := &fake.Service{}
+
+			if test.setup != nil {
+				test.setup(svc)
+			}
+
+			r := NewIngressReconciler(client, svc, &test.options)
+
+			result, err := r.Reconcile(test.req)
+			if test.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expected, result)
+			}
+
+			if test.validate != nil {
+				test.validate(t, client, svc)
+			}
+		})
+	}
+}
+
+func TestIngressReconciler_Reconcile_DelayCreation(t *testing.T) {
+	client := fakeclient.NewFakeClient(&v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bar",
+			Namespace: "kube-system",
+			Annotations: map[string]string{
+				config.AnnotationEnabled: "true",
+			},
+			CreationTimestamp: metav1.Now(),
+		},
+	})
+
+	r := NewIngressReconciler(client, &fake.Service{}, &config.Options{
+		CreationDelay: 1 * time.Minute,
+	})
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "bar",
+			Namespace: "kube-system",
+		},
+	}
+
+	result, err := r.Reconcile(req)
+	require.NoError(t, err)
+
+	if result.RequeueAfter <= 0 {
+		t.Fatalf("expected result.RequeueAfter to be greater than 0, got %s", result.RequeueAfter)
+	}
+}

--- a/pkg/monitor/fake/service.go
+++ b/pkg/monitor/fake/service.go
@@ -1,0 +1,39 @@
+package fake
+
+import (
+	"github.com/stretchr/testify/mock"
+	"k8s.io/api/extensions/v1beta1"
+)
+
+type Service struct {
+	mock.Mock
+}
+
+func (s *Service) EnsureMonitor(ingress *v1beta1.Ingress) error {
+	args := s.Called(ingress)
+
+	return args.Error(0)
+}
+
+func (s *Service) DeleteMonitor(ingress *v1beta1.Ingress) error {
+	args := s.Called(ingress)
+
+	return args.Error(0)
+}
+
+func (s *Service) GetProviderIPSourceRanges(ingress *v1beta1.Ingress) ([]string, error) {
+	args := s.Called(ingress)
+
+	var ips []string
+	if arg, ok := args.Get(0).([]string); ok {
+		ips = arg
+	}
+
+	return ips, args.Error(1)
+}
+
+func (s *Service) AnnotateIngress(ingress *v1beta1.Ingress) (updated bool, err error) {
+	args := s.Called(ingress)
+
+	return args.Bool(0), args.Error(1)
+}


### PR DESCRIPTION
This PR adds tests for the ingress reconciler and makes a small improvement to the logic that handles the creation delay. The creation delay should only be honored if the ingress has the `ingress-monitor.bonial.com/enabled` annotation set to `true`.

The PR also adds a reusable mock for the `monitor.Service`.