### PR TITLE
add metrics for monitor stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,22 @@ annotation of an ingress if the following rules apply:
 - If the provider source ranges are not already present in the
   `nginx.ingress.kubernetes.io/whitelist-source-range` annotation, add them
   automatically.
+
+Limitations
+-----------
+
+The controller only creates monitors for the host defined in the first ingress
+rule (`spec.rules[0].host`), or if using TLS, for the first host in the TLS
+spec (`spec.tls[0].hosts[0]`), and only if those do not contain wildcards
+(`*`). If you want to create monitors for multiple hostnames, simply create
+dedicated ingress objects for them.
+
+Metrics
+-------
+
+Prometheus metrics are exposed at `0.0.0.0:8080/metrics`. Besides the metrics
+provided by the kubernetes
+[controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) the
+ingress-monitor-controller also exposes metric stats about monitor creations,
+updates and deletions prefixed with `ingress_monitor_controller_*`, see
+[`pkg/monitor/metrics`](https://godoc.org/github.com/Bonial-International-GmbH/ingress-monitor-controller/pkg/monitor/metrics).

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Bonial-International-GmbH/site24x7-go v0.0.3
 	github.com/imdario/mergo v0.3.6
 	github.com/pkg/errors v0.8.1
+	github.com/prometheus/client_golang v1.0.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,7 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
@@ -220,9 +221,11 @@ github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:v
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.11.0 h1:JAKSXpt1YjtLA7YpPiqO9ss6sNXEsPfSGdwN0UHqzrw=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.8.1 h1:C5Dqfs/LeauYDX0jJXIe2SWmwCbGzx9yF8C8xy3Lh34=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -379,6 +382,7 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
@@ -406,6 +410,7 @@ gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/monitor/metrics/metrics.go
+++ b/pkg/monitor/metrics/metrics.go
@@ -1,0 +1,50 @@
+// Package metrics provides prometheus metric declarations to collect stats
+// about monitor creations/updates/deletions.
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// MonitorsCreatedTotal is a counter for the total number of successful
+	// ingress monitor creation operations.
+	MonitorsCreatedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "ingress_monitor_controller_monitors_created_total",
+		Help: "Total number of ingress monitors created by monitor",
+	}, []string{"monitor"})
+
+	// MonitorsUpdatedTotal is a counter for the total number of successful
+	// ingress monitor update operations.
+	MonitorsUpdatedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "ingress_monitor_controller_monitors_updated_total",
+		Help: "Total number of ingress monitors updated by monitor",
+	}, []string{"monitor"})
+
+	// MonitorsDeletedTotal is a counter for the total number of successful
+	// ingress monitor deletion operations.
+	MonitorsDeletedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "ingress_monitor_controller_monitors_deleted_total",
+		Help: "Total number of ingress monitors deleted by monitor",
+	}, []string{"monitor"})
+
+	// IngressValidationErrorsTotal is a counter for the total number of failed
+	// ingress validation events. That is: monitor creation was requested for
+	// an ingress that was not eligible as a target for an ingress monitor. See
+	// the doc of pkg/ingress.Validate for an explanation of the validation
+	// rules.
+	IngressValidationErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "ingress_monitor_controller_ingress_validation_errors_total",
+		Help: "Total number of ingress validation errors by namespace and ingress name",
+	}, []string{"namespace", "name"})
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		MonitorsCreatedTotal,
+		MonitorsUpdatedTotal,
+		MonitorsDeletedTotal,
+		IngressValidationErrorsTotal,
+	)
+}


### PR DESCRIPTION
This adds counter metrics for monitor create/update/delete operations
and ingress validation errors. These can help us to build dashboards for
the controller and also detect ingress config validation errors.

Also the limitations section was added to README.md.