### PR TITLE
chore: switch from extensions/v1beta1 to networking.k8s.io/v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ site24x7:
 To automatically create a website monitor for an ingress, it requires to be annotated with the `ingress-monitor.bonial.com/enabled` annotation:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -7,7 +7,6 @@ metadata:
   name: ingress-monitor-controller
 rules:
   - apiGroups:
-      - extensions
       - networking.k8s.io
     resources:
       - ingresses

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	runtime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	restconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -99,7 +99,7 @@ func Run(options *config.Options) error {
 	err = builder.
 		ControllerManagedBy(mgr).
 		Named("ingress-monitor-controller").
-		For(&v1beta1.Ingress{}).
+		For(&networkingv1.Ingress{}).
 		Complete(reconciler)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create controller")

--- a/pkg/controller/reconciler_test.go
+++ b/pkg/controller/reconciler_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Bonial-International-GmbH/ingress-monitor-controller/pkg/monitor/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,7 +37,7 @@ func TestIngressReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			setup: func(s *fake.Service) {
-				s.On("DeleteMonitor", &v1beta1.Ingress{
+				s.On("DeleteMonitor", &networkingv1.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "kube-system",
@@ -54,7 +54,7 @@ func TestIngressReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			clientFn: func() client.Client {
-				return fakeclient.NewFakeClient(&v1beta1.Ingress{
+				return fakeclient.NewFakeClient(&networkingv1.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
 						Namespace: "kube-system",
@@ -65,10 +65,10 @@ func TestIngressReconciler_Reconcile(t *testing.T) {
 				})
 			},
 			setup: func(s *fake.Service) {
-				ing := &v1beta1.Ingress{
+				ing := &networkingv1.Ingress{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Ingress",
-						APIVersion: "extensions/v1beta1",
+						APIVersion: "networking.k8s.io/v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
@@ -93,7 +93,7 @@ func TestIngressReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			clientFn: func() client.Client {
-				return fakeclient.NewFakeClient(&v1beta1.Ingress{
+				return fakeclient.NewFakeClient(&networkingv1.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
 						Namespace: "kube-system",
@@ -104,10 +104,10 @@ func TestIngressReconciler_Reconcile(t *testing.T) {
 				})
 			},
 			setup: func(s *fake.Service) {
-				ing := &v1beta1.Ingress{
+				ing := &networkingv1.Ingress{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Ingress",
-						APIVersion: "extensions/v1beta1",
+						APIVersion: "networking.k8s.io/v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
@@ -131,7 +131,7 @@ func TestIngressReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			clientFn: func() client.Client {
-				return fakeclient.NewFakeClient(&v1beta1.Ingress{
+				return fakeclient.NewFakeClient(&networkingv1.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
 						Namespace: "kube-system",
@@ -139,10 +139,10 @@ func TestIngressReconciler_Reconcile(t *testing.T) {
 				})
 			},
 			setup: func(s *fake.Service) {
-				s.On("DeleteMonitor", &v1beta1.Ingress{
+				s.On("DeleteMonitor", &networkingv1.Ingress{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Ingress",
-						APIVersion: "extensions/v1beta1",
+						APIVersion: "networking.k8s.io/v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "bar",
@@ -188,7 +188,7 @@ func TestIngressReconciler_Reconcile(t *testing.T) {
 }
 
 func TestIngressReconciler_Reconcile_DelayCreation(t *testing.T) {
-	client := fakeclient.NewFakeClient(&v1beta1.Ingress{
+	client := fakeclient.NewFakeClient(&networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
 			Namespace: "kube-system",

--- a/pkg/ingress/ingress_test.go
+++ b/pkg/ingress/ingress_test.go
@@ -7,21 +7,21 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestValidate(t *testing.T) {
 	tests := []struct {
 		name     string
-		ingress  *v1beta1.Ingress
+		ingress  *networkingv1.Ingress
 		expected error
 	}{
 		{
 			name: "valid ingress without TLS",
-			ingress: &v1beta1.Ingress{
-				Spec: v1beta1.IngressSpec{
-					Rules: []v1beta1.IngressRule{
+			ingress: &networkingv1.Ingress{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},
@@ -29,12 +29,12 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "valid ingress with TLS",
-			ingress: &v1beta1.Ingress{
-				Spec: v1beta1.IngressSpec{
-					TLS: []v1beta1.IngressTLS{
+			ingress: &networkingv1.Ingress{
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
 						{Hosts: []string{"foo.bar.baz"}},
 					},
-					Rules: []v1beta1.IngressRule{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},
@@ -42,12 +42,12 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "wildcard TLS hosts are not supported",
-			ingress: &v1beta1.Ingress{
-				Spec: v1beta1.IngressSpec{
-					TLS: []v1beta1.IngressTLS{
+			ingress: &networkingv1.Ingress{
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
 						{Hosts: []string{"*.bar.baz"}},
 					},
-					Rules: []v1beta1.IngressRule{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},
@@ -56,9 +56,9 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "wildcard hosts are not supported",
-			ingress: &v1beta1.Ingress{
-				Spec: v1beta1.IngressSpec{
-					Rules: []v1beta1.IngressRule{
+			ingress: &networkingv1.Ingress{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
 						{Host: "*.bar.baz"},
 					},
 				},
@@ -67,7 +67,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name:     "ingress needs to have at least one rule",
-			ingress:  &v1beta1.Ingress{},
+			ingress:  &networkingv1.Ingress{},
 			expected: errors.New(`ingress does not have any rules`),
 		},
 	}
@@ -88,14 +88,14 @@ func TestValidate(t *testing.T) {
 func TestBuildMonitorURL(t *testing.T) {
 	tests := []struct {
 		name     string
-		ingress  *v1beta1.Ingress
+		ingress  *networkingv1.Ingress
 		expected string
 	}{
 		{
 			name: "simple http url",
-			ingress: &v1beta1.Ingress{
-				Spec: v1beta1.IngressSpec{
-					Rules: []v1beta1.IngressRule{
+			ingress: &networkingv1.Ingress{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},
@@ -104,12 +104,12 @@ func TestBuildMonitorURL(t *testing.T) {
 		},
 		{
 			name: "https url via TLS config",
-			ingress: &v1beta1.Ingress{
-				Spec: v1beta1.IngressSpec{
-					TLS: []v1beta1.IngressTLS{
+			ingress: &networkingv1.Ingress{
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
 						{Hosts: []string{"foo.bar.baz"}},
 					},
-					Rules: []v1beta1.IngressRule{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},
@@ -118,14 +118,14 @@ func TestBuildMonitorURL(t *testing.T) {
 		},
 		{
 			name: "https url via nginx ingress redirect annotation",
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						nginxForceSSLRedirectAnnotation: "true",
 					},
 				},
-				Spec: v1beta1.IngressSpec{
-					Rules: []v1beta1.IngressRule{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},
@@ -134,14 +134,14 @@ func TestBuildMonitorURL(t *testing.T) {
 		},
 		{
 			name: "https url via force https annotation",
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						config.AnnotationForceHTTPS: "true",
 					},
 				},
-				Spec: v1beta1.IngressSpec{
-					Rules: []v1beta1.IngressRule{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},
@@ -150,15 +150,15 @@ func TestBuildMonitorURL(t *testing.T) {
 		},
 		{
 			name: "respect path override annotation",
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						config.AnnotationForceHTTPS:   "true",
 						config.AnnotationPathOverride: "health",
 					},
 				},
-				Spec: v1beta1.IngressSpec{
-					Rules: []v1beta1.IngressRule{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},

--- a/pkg/monitor/annotation.go
+++ b/pkg/monitor/annotation.go
@@ -4,13 +4,13 @@ import (
 	"strings"
 
 	"github.com/Bonial-International-GmbH/ingress-monitor-controller/pkg/config"
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 const nginxWhitelistSourceRangeAnnotation = "nginx.ingress.kubernetes.io/whitelist-source-range"
 
 // AnnotateIngress implements Service.
-func (s *service) AnnotateIngress(ingress *v1beta1.Ingress) (bool, error) {
+func (s *service) AnnotateIngress(ingress *networkingv1.Ingress) (bool, error) {
 	log := log.WithValues("namespace", ingress.Namespace, "name", ingress.Name)
 
 	if !shouldPatchSourceRangeWhitelist(ingress) {
@@ -48,7 +48,7 @@ func (s *service) AnnotateIngress(ingress *v1beta1.Ingress) (bool, error) {
 // monitor enabled and has configured the
 // nginx.ingress.kubernetes.io/whitelist-source-range annotation to only allow
 // traffic from whitelisted sources.
-func shouldPatchSourceRangeWhitelist(ingress *v1beta1.Ingress) bool {
+func shouldPatchSourceRangeWhitelist(ingress *networkingv1.Ingress) bool {
 	annotations := config.Annotations(ingress.Annotations)
 
 	if !annotations.BoolValue(config.AnnotationEnabled) {

--- a/pkg/monitor/annotation_test.go
+++ b/pkg/monitor/annotation_test.go
@@ -9,35 +9,35 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestService_AnnotateIngress(t *testing.T) {
 	tests := []struct {
 		name        string
-		ingress     *v1beta1.Ingress
+		ingress     *networkingv1.Ingress
 		expected    bool
 		expectedErr error
 		setup       func(*fake.Provider)
-		validate    func(*testing.T, *v1beta1.Ingress, *fake.Provider)
+		validate    func(*testing.T, *networkingv1.Ingress, *fake.Provider)
 	}{
 		{
 			name: "ingress objects without monitor annotation are not updated",
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
 				},
 			},
 			expected: false,
-			validate: func(t *testing.T, ingress *v1beta1.Ingress, _ *fake.Provider) {
+			validate: func(t *testing.T, ingress *networkingv1.Ingress, _ *fake.Provider) {
 				assert.Nil(t, ingress.Annotations)
 			},
 		},
 		{
 			name: `ingress objects with monitor annotation with value "false" are not updated`,
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
@@ -47,7 +47,7 @@ func TestService_AnnotateIngress(t *testing.T) {
 				},
 			},
 			expected: false,
-			validate: func(t *testing.T, ingress *v1beta1.Ingress, _ *fake.Provider) {
+			validate: func(t *testing.T, ingress *networkingv1.Ingress, _ *fake.Provider) {
 				assert.Equal(t, ingress.Annotations, map[string]string{
 					config.AnnotationEnabled: "false",
 				})
@@ -55,7 +55,7 @@ func TestService_AnnotateIngress(t *testing.T) {
 		},
 		{
 			name: `ingress objects without source range whitelist annotation are not updated`,
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
@@ -64,7 +64,7 @@ func TestService_AnnotateIngress(t *testing.T) {
 					},
 				},
 			},
-			validate: func(t *testing.T, ingress *v1beta1.Ingress, _ *fake.Provider) {
+			validate: func(t *testing.T, ingress *networkingv1.Ingress, _ *fake.Provider) {
 				assert.Equal(t, ingress.Annotations, map[string]string{
 					config.AnnotationEnabled: "true",
 				})
@@ -72,7 +72,7 @@ func TestService_AnnotateIngress(t *testing.T) {
 		},
 		{
 			name: `error while retrieving provider source ranges`,
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
@@ -81,8 +81,8 @@ func TestService_AnnotateIngress(t *testing.T) {
 						nginxWhitelistSourceRangeAnnotation: "5.6.7.8/32,1.2.3.4/32,9.10.11.12/32",
 					},
 				},
-				Spec: v1beta1.IngressSpec{
-					Rules: []v1beta1.IngressRule{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},
@@ -94,7 +94,7 @@ func TestService_AnnotateIngress(t *testing.T) {
 		},
 		{
 			name: `empty provider source ranges do not cause the object to be patched`,
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
@@ -103,8 +103,8 @@ func TestService_AnnotateIngress(t *testing.T) {
 						nginxWhitelistSourceRangeAnnotation: "5.6.7.8/32,1.2.3.4/32,9.10.11.12/32",
 					},
 				},
-				Spec: v1beta1.IngressSpec{
-					Rules: []v1beta1.IngressRule{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},
@@ -112,13 +112,13 @@ func TestService_AnnotateIngress(t *testing.T) {
 			setup: func(p *fake.Provider) {
 				p.On("GetIPSourceRanges", mock.Anything).Return(nil, nil)
 			},
-			validate: func(t *testing.T, ingress *v1beta1.Ingress, _ *fake.Provider) {
+			validate: func(t *testing.T, ingress *networkingv1.Ingress, _ *fake.Provider) {
 				assert.Equal(t, "5.6.7.8/32,1.2.3.4/32,9.10.11.12/32", ingress.Annotations[nginxWhitelistSourceRangeAnnotation])
 			},
 		},
 		{
 			name: `provider source ranges are merged with the configured whitelist annotation`,
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
@@ -127,8 +127,8 @@ func TestService_AnnotateIngress(t *testing.T) {
 						nginxWhitelistSourceRangeAnnotation: "1.2.3.4/32",
 					},
 				},
-				Spec: v1beta1.IngressSpec{
-					Rules: []v1beta1.IngressRule{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},
@@ -137,13 +137,13 @@ func TestService_AnnotateIngress(t *testing.T) {
 				p.On("GetIPSourceRanges", mock.Anything).Return([]string{"5.6.7.8/32"}, nil)
 			},
 			expected: true,
-			validate: func(t *testing.T, ingress *v1beta1.Ingress, _ *fake.Provider) {
+			validate: func(t *testing.T, ingress *networkingv1.Ingress, _ *fake.Provider) {
 				assert.Equal(t, "1.2.3.4/32,5.6.7.8/32", ingress.Annotations[nginxWhitelistSourceRangeAnnotation])
 			},
 		},
 		{
 			name: `already present source ranges are not added again`,
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
@@ -152,8 +152,8 @@ func TestService_AnnotateIngress(t *testing.T) {
 						nginxWhitelistSourceRangeAnnotation: "1.2.3.4/32",
 					},
 				},
-				Spec: v1beta1.IngressSpec{
-					Rules: []v1beta1.IngressRule{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},
@@ -162,13 +162,13 @@ func TestService_AnnotateIngress(t *testing.T) {
 				p.On("GetIPSourceRanges", mock.Anything).Return([]string{"5.6.7.8/32", "1.2.3.4/32"}, nil)
 			},
 			expected: true,
-			validate: func(t *testing.T, ingress *v1beta1.Ingress, _ *fake.Provider) {
+			validate: func(t *testing.T, ingress *networkingv1.Ingress, _ *fake.Provider) {
 				assert.Equal(t, "1.2.3.4/32,5.6.7.8/32", ingress.Annotations[nginxWhitelistSourceRangeAnnotation])
 			},
 		},
 		{
 			name: `if provider source ranges are already whitelisted, no patch is created`,
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
@@ -177,8 +177,8 @@ func TestService_AnnotateIngress(t *testing.T) {
 						nginxWhitelistSourceRangeAnnotation: "5.6.7.8/32,1.2.3.4/32",
 					},
 				},
-				Spec: v1beta1.IngressSpec{
-					Rules: []v1beta1.IngressRule{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},
@@ -187,7 +187,7 @@ func TestService_AnnotateIngress(t *testing.T) {
 				p.On("GetIPSourceRanges", mock.Anything).Return([]string{"5.6.7.8/32"}, nil)
 			},
 			expected: false,
-			validate: func(t *testing.T, ingress *v1beta1.Ingress, _ *fake.Provider) {
+			validate: func(t *testing.T, ingress *networkingv1.Ingress, _ *fake.Provider) {
 				assert.Equal(t, "5.6.7.8/32,1.2.3.4/32", ingress.Annotations[nginxWhitelistSourceRangeAnnotation])
 			},
 		},

--- a/pkg/monitor/fake/service.go
+++ b/pkg/monitor/fake/service.go
@@ -2,26 +2,26 @@ package fake
 
 import (
 	"github.com/stretchr/testify/mock"
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 type Service struct {
 	mock.Mock
 }
 
-func (s *Service) EnsureMonitor(ingress *v1beta1.Ingress) error {
+func (s *Service) EnsureMonitor(ingress *networkingv1.Ingress) error {
 	args := s.Called(ingress)
 
 	return args.Error(0)
 }
 
-func (s *Service) DeleteMonitor(ingress *v1beta1.Ingress) error {
+func (s *Service) DeleteMonitor(ingress *networkingv1.Ingress) error {
 	args := s.Called(ingress)
 
 	return args.Error(0)
 }
 
-func (s *Service) GetProviderIPSourceRanges(ingress *v1beta1.Ingress) ([]string, error) {
+func (s *Service) GetProviderIPSourceRanges(ingress *networkingv1.Ingress) ([]string, error) {
 	args := s.Called(ingress)
 
 	var ips []string
@@ -32,7 +32,7 @@ func (s *Service) GetProviderIPSourceRanges(ingress *v1beta1.Ingress) ([]string,
 	return ips, args.Error(1)
 }
 
-func (s *Service) AnnotateIngress(ingress *v1beta1.Ingress) (updated bool, err error) {
+func (s *Service) AnnotateIngress(ingress *networkingv1.Ingress) (updated bool, err error) {
 	args := s.Called(ingress)
 
 	return args.Bool(0), args.Error(1)

--- a/pkg/monitor/namer.go
+++ b/pkg/monitor/namer.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"text/template"
 
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 type templateArgs struct {
@@ -34,7 +34,7 @@ func NewNamer(nameTemplate string) (*Namer, error) {
 
 // Name builds a monitor name for given ingress. Returns an error if rendering
 // the name template fails.
-func (n *Namer) Name(ingress *v1beta1.Ingress) (string, error) {
+func (n *Namer) Name(ingress *networkingv1.Ingress) (string, error) {
 	var buf bytes.Buffer
 
 	err := n.template.Execute(&buf, templateArgs{

--- a/pkg/monitor/service_test.go
+++ b/pkg/monitor/service_test.go
@@ -10,14 +10,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestService_EnsureMonitor(t *testing.T) {
 	tests := []struct {
 		name     string
-		ingress  *v1beta1.Ingress
+		ingress  *networkingv1.Ingress
 		options  config.Options
 		setup    func(*fake.Provider)
 		validate func(*testing.T, *fake.Provider)
@@ -25,7 +25,7 @@ func TestService_EnsureMonitor(t *testing.T) {
 	}{
 		{
 			name: "invalid ingress is ignored without error",
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
@@ -37,7 +37,7 @@ func TestService_EnsureMonitor(t *testing.T) {
 		},
 		{
 			name: "non-existent monitor is created",
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
@@ -45,8 +45,8 @@ func TestService_EnsureMonitor(t *testing.T) {
 						config.AnnotationEnabled: "true",
 					},
 				},
-				Spec: v1beta1.IngressSpec{
-					Rules: []v1beta1.IngressRule{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},
@@ -64,7 +64,7 @@ func TestService_EnsureMonitor(t *testing.T) {
 		},
 		{
 			name: "existing monitor is created",
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
@@ -72,8 +72,8 @@ func TestService_EnsureMonitor(t *testing.T) {
 						config.AnnotationEnabled: "true",
 					},
 				},
-				Spec: v1beta1.IngressSpec{
-					Rules: []v1beta1.IngressRule{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},
@@ -96,7 +96,7 @@ func TestService_EnsureMonitor(t *testing.T) {
 		},
 		{
 			name: "does not create/update monitor if lookup fails",
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
@@ -104,8 +104,8 @@ func TestService_EnsureMonitor(t *testing.T) {
 						config.AnnotationEnabled: "true",
 					},
 				},
-				Spec: v1beta1.IngressSpec{
-					Rules: []v1beta1.IngressRule{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},
@@ -147,7 +147,7 @@ func TestService_EnsureMonitor(t *testing.T) {
 func TestService_DeleteMonitor(t *testing.T) {
 	tests := []struct {
 		name     string
-		ingress  *v1beta1.Ingress
+		ingress  *networkingv1.Ingress
 		options  config.Options
 		setup    func(*fake.Provider)
 		validate func(*testing.T, *fake.Provider)
@@ -155,7 +155,7 @@ func TestService_DeleteMonitor(t *testing.T) {
 	}{
 		{
 			name: "delete monitor for ingress",
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
@@ -170,7 +170,7 @@ func TestService_DeleteMonitor(t *testing.T) {
 		},
 		{
 			name: "deletion of nonexistant monitor does not error",
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
@@ -186,7 +186,7 @@ func TestService_DeleteMonitor(t *testing.T) {
 		{
 			name:    "no deletions if NoDelete options is set",
 			options: config.Options{NoDelete: true},
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
@@ -224,7 +224,7 @@ func TestService_DeleteMonitor(t *testing.T) {
 func TestService_GetProviderIPSourceRanges(t *testing.T) {
 	tests := []struct {
 		name        string
-		ingress     *v1beta1.Ingress
+		ingress     *networkingv1.Ingress
 		options     config.Options
 		setup       func(*fake.Provider)
 		expected    []string
@@ -232,7 +232,7 @@ func TestService_GetProviderIPSourceRanges(t *testing.T) {
 	}{
 		{
 			name: "unsupported ingresses produce empty result and no error",
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
@@ -241,13 +241,13 @@ func TestService_GetProviderIPSourceRanges(t *testing.T) {
 		},
 		{
 			name: "invalid ingress returns error",
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
 				},
-				Spec: v1beta1.IngressSpec{
-					Rules: []v1beta1.IngressRule{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
 						{Host: "{invalidhost"},
 					},
 				},
@@ -256,13 +256,13 @@ func TestService_GetProviderIPSourceRanges(t *testing.T) {
 		},
 		{
 			name: "returns source ranges for ingress",
-			ingress: &v1beta1.Ingress{
+			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "kube-system",
 				},
-				Spec: v1beta1.IngressSpec{
-					Rules: []v1beta1.IngressRule{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
 						{Host: "foo.bar.baz"},
 					},
 				},


### PR DESCRIPTION
Move to `networking.k8s.io/v1` for ingresses as `extensions/v1beta1` was deprecated and will be removed in future Kubernetes versions.